### PR TITLE
Remove 'Entering DMUMPS driver' messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 env:
   global:
     - BINARYBUILDER_DOWNLOADS_CACHE=downloads
-    - BINARYBUILDER_AUTOMATIC_APPLE=false
+    - BINARYBUILDER_AUTOMATIC_APPLE=true
 sudo: required
 
 # Before anything else, get the latest versions of things

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -32,6 +32,8 @@ fi
 
 ## First build SDPA
 
+mv $WORKSPACE/srcdir/patches/quiet.diff .
+patch -p1 < $WORKSPACE/srcdir/patches/apply_quiet.diff
 patch -p1 < $WORKSPACE/srcdir/patches/shared.diff
 mv configure.in configure.ac
 patch -p1 < $WORKSPACE/srcdir/patches/lt_init.diff

--- a/bundled/patches/apply_quiet.diff
+++ b/bundled/patches/apply_quiet.diff
@@ -1,0 +1,12 @@
+diff --git a/mumps/Makefile b/mumps/Makefile
+index da175ce..4efad51 100644
+--- a/mumps/Makefile
++++ b/mumps/Makefile
+@@ -26,6 +26,7 @@ build/lib/libdmumps.a:${MUMPS_TAR_FILE}
+ 	rm -rf build;
+ 	tar xzf ${MUMPS_TAR_FILE}
+ 	mv mumps-${MUMPS_VER}/ build;
++	patch -p1 < ../quiet.diff
+ 	cd build; cp Make.inc/Makefile.inc.generic.SEQ Makefile.inc;
+ 
+ 	cd build; echo "CC = "   ${CC}       >> Makefile.inc;

--- a/bundled/patches/quiet.diff
+++ b/bundled/patches/quiet.diff
@@ -1,0 +1,21 @@
+diff --git a/mumps/build/src/dmumps_part1.F b/mumps/build/src/dmumps_part1.F
+index af0b62a..55e372e 100644
+--- a/build/src/dmumps_part1.F
++++ b/build/src/dmumps_part1.F
+@@ -104,16 +104,6 @@ C       matrix in assembled format (ICNTL(5)=0, and ICNTL(18) $\neq$ 3),
+         MPG     = id%ICNTL(3)
+         PROK    = ((MP.GT.0).AND.(id%ICNTL(4).GE.3))
+         PROKG   = ( MPG .GT. 0 .and. id%MYID .eq. MASTER )
+-        IF (PROKG) THEN
+-           IF (id%ICNTL(5) .NE. 1) THEN
+-              WRITE(MPG,'(A,I4,I12,I15)') 
+-     &             'Entering DMUMPS driver with JOB, N, NZ =', JOB,N,NZ
+-           ELSE
+-              WRITE(MPG,'(A,I4,I12,I15)') 
+-     &             'Entering DMUMPS driver with JOB, N, NELT =', JOB,N
+-     &             ,NELT
+-           ENDIF
+-        ENDIF
+       ELSE
+         MPG = 0
+         PROK = .FALSE.


### PR DESCRIPTION
Remove the message
```
Entering DMUMPS driver with JOB, N, NZ =  -2           0              0
```
that SDPA prints at each solve (hence carrying 0 bit of information).